### PR TITLE
NuGet LabAPI + permission check wrapper overloads

### DIFF
--- a/SecretAPI.Examples/SecretAPI.Examples.csproj
+++ b/SecretAPI.Examples/SecretAPI.Examples.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
         <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+        <PackageReference Include="Northwood.LabAPI" Version="1.0.2" IncludeAssets="All" PrivateAssets="All" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" IncludeAssets="All" PrivateAssets="All" />
     </ItemGroup>
 
@@ -16,7 +17,6 @@
         <ProjectReference Include="..\SecretAPI\SecretAPI.csproj" />
         <Reference Include="Assembly-CSharp" HintPath="$(SL_REFERENCES)\Assembly-CSharp.dll" Publicize="true" />
         <Reference Include="CommandSystem.Core" HintPath="$(SL_REFERENCES)\CommandSystem.Core.dll" />
-        <Reference Include="LabApi" HintPath="$(SL_REFERENCES)\LabApi.dll" />
         <Reference Include="NorthwoodLib" HintPath="$(SL_REFERENCES)\NorthwoodLib.dll" />
         <Reference Include="Assembly-CSharp-firstpass" HintPath="$(SL_REFERENCES)\Assembly-CSharp-firstpass.dll" />
         <Reference Include="Pooling" HintPath="$(SL_REFERENCES)\Pooling.dll" />

--- a/SecretAPI/Enums/DoorPermissionCheck.cs
+++ b/SecretAPI/Enums/DoorPermissionCheck.cs
@@ -1,13 +1,14 @@
 ﻿namespace SecretAPI.Enums
 {
     using System;
+    using Interactables.Interobjects.DoorUtils;
     using LabApi.Features.Wrappers;
     using PlayerRoles;
     using PlayerStatsSystem;
     using SecretAPI.Extensions;
 
     /// <summary>
-    /// Flags to use for <see cref="PlayerExtensions.HasDoorPermission"/>.
+    /// Flags to use for <see cref="PlayerExtensions.HasDoorPermission(Player,IDoorPermissionRequester,DoorPermissionCheck)"/>.
     /// </summary>
     [Flags]
     public enum DoorPermissionCheck
@@ -46,5 +47,10 @@
         /// Used to consider all.
         /// </summary>
         All = Bypass | Role | FullInventory,
+
+        /// <summary>
+        /// Used to mirror default base-game checks (bypass mode, role and held item).
+        /// </summary>
+        Default = Bypass | Role | CurrentItem,
     }
 }

--- a/SecretAPI/Extensions/PlayerExtensions.cs
+++ b/SecretAPI/Extensions/PlayerExtensions.cs
@@ -28,10 +28,10 @@
         /// Checks whether a player has permission to access a <see cref="IDoorPermissionRequester"/>.
         /// </summary>
         /// <param name="player">The player to check.</param>
-        /// <param name="requester">The requester to check the player for permissions on.</param>
+        /// <param name="requester">The requester to check for permissions.</param>
         /// <param name="checkFlags">The <see cref="DoorPermissionCheck"/> to use for checking if a player has it.</param>
         /// <returns>Whether a valid permission was found.</returns>
-        public static bool HasDoorPermission(this Player player, IDoorPermissionRequester requester, DoorPermissionCheck checkFlags = DoorPermissionCheck.Bypass | DoorPermissionCheck.Role | DoorPermissionCheck.CurrentItem)
+        public static bool HasDoorPermission(this Player player, IDoorPermissionRequester requester, DoorPermissionCheck checkFlags = DoorPermissionCheck.Default)
         {
             if (checkFlags.HasFlag(DoorPermissionCheck.Bypass) && player.IsBypassEnabled)
                 return true;
@@ -48,11 +48,41 @@
                 if (!checkFlags.HasFlag(DoorPermissionCheck.InventoryExludingCurrent) && !isCurrent)
                     continue;
 
-                if (item?.Base is IDoorPermissionProvider itemProvider && requester.PermissionsPolicy.CheckPermissions(itemProvider.GetPermissions(requester)))
+                if (item.Base is IDoorPermissionProvider itemProvider && requester.PermissionsPolicy.CheckPermissions(itemProvider.GetPermissions(requester)))
                     return true;
             }
 
             return false;
         }
+
+        /// <summary>
+        /// Checks whether a player has permission to access a <see cref="Door"/>.
+        /// </summary>
+        /// <param name="player">The player to check.</param>
+        /// <param name="door">The door to check for permissions.</param>
+        /// <param name="checkFlags">The <see cref="DoorPermissionCheck"/> to use for checking if a player has it.</param>
+        /// <returns>Whether a valid permission was found.</returns>
+        public static bool HasDoorPermission(this Player player, Door door, DoorPermissionCheck checkFlags = DoorPermissionCheck.Default)
+            => player.HasDoorPermission(door.Base, checkFlags);
+
+        /// <summary>
+        /// Checks whether a player has permission to access a <see cref="LockerChamber"/>.
+        /// </summary>
+        /// <param name="player">The player to check.</param>
+        /// <param name="chamber">The locker chamber to check for permissions.</param>
+        /// <param name="checkFlags">The <see cref="DoorPermissionCheck"/> to use for checking if a player has it.</param>
+        /// <returns>Whether a valid permission was found.</returns>
+        public static bool HasLockerChamberPermission(this Player player, LockerChamber chamber, DoorPermissionCheck checkFlags = DoorPermissionCheck.Default)
+            => player.HasDoorPermission(chamber.Base, checkFlags);
+
+        /// <summary>
+        /// Checks whether a player has permission to access a <see cref="Generator"/>.
+        /// </summary>
+        /// <param name="player">The player to check.</param>
+        /// <param name="generator">The generator to check for permissions.</param>
+        /// <param name="checkFlags">The <see cref="DoorPermissionCheck"/> to use for checking if a player has it.</param>
+        /// <returns>Whether a valid permission was found.</returns>
+        public static bool HasGeneratorPermission(this Player player, Generator generator, DoorPermissionCheck checkFlags = DoorPermissionCheck.Default)
+            => player.HasDoorPermission(generator.Base, checkFlags);
     }
 }

--- a/SecretAPI/SecretAPI.csproj
+++ b/SecretAPI/SecretAPI.csproj
@@ -28,6 +28,7 @@
     
     <ItemGroup>
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
+        <PackageReference Include="Northwood.LabAPI" Version="1.0.2" IncludeAssets="All" PrivateAssets="All" />
         <PackageReference Include="Lib.Harmony" Version="2.2.2" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" IncludeAssets="All" PrivateAssets="All" />
     </ItemGroup>
@@ -35,7 +36,6 @@
     <ItemGroup>
         <Reference Include="Assembly-CSharp" HintPath="$(SL_REFERENCES)\Assembly-CSharp.dll" Publicize="true" />
         <Reference Include="CommandSystem.Core" HintPath="$(SL_REFERENCES)\CommandSystem.Core.dll" />
-        <Reference Include="LabApi" HintPath="$(SL_REFERENCES)\LabApi.dll" />
         <Reference Include="NorthwoodLib" HintPath="$(SL_REFERENCES)\NorthwoodLib.dll" />
         <Reference Include="Assembly-CSharp-firstpass" HintPath="$(SL_REFERENCES)\Assembly-CSharp-firstpass.dll" />
         <Reference Include="Pooling" HintPath="$(SL_REFERENCES)\Pooling.dll" />


### PR DESCRIPTION
Changed the LabAPI references to be obtained via NuGet.
Added a `Default` value to `DoorPermissionCheck` that reflects base-game behavior. Added overloads for checking permissions of `Door` `LockerChamber` and `Generator` wrappers.
Removed a redundant null check.
Fixed the phrasing of a sentence in XML docs.
Set the default value of the `checkFlags` parameter to the new `Default` enum value.