### PR TITLE
Bump to 2.0.2

### DIFF
--- a/SecretAPI.Examples/SecretAPI.Examples.csproj
+++ b/SecretAPI.Examples/SecretAPI.Examples.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
         <PackageReference Include="Lib.Harmony" Version="2.2.2" />
-        <PackageReference Include="Northwood.LabAPI" Version="1.1.3" IncludeAssets="All" PrivateAssets="All" />
+        <PackageReference Include="Northwood.LabAPI" Version="1.1.4" IncludeAssets="All" PrivateAssets="All" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" IncludeAssets="All" PrivateAssets="All" />
     </ItemGroup>
 

--- a/SecretAPI/Attribute/CallOnUnloadAttribute.cs
+++ b/SecretAPI/Attribute/CallOnUnloadAttribute.cs
@@ -1,15 +1,14 @@
 ﻿namespace SecretAPI.Attribute
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
+    using SecretAPI.Features;
 
     /// <summary>
     /// Defines the attribute for methods to call on unload.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class CallOnUnloadAttribute : Attribute
+    public class CallOnUnloadAttribute : Attribute, IPriority
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CallOnUnloadAttribute"/> class.
@@ -32,26 +31,7 @@
         public static void Unload(Assembly? assembly = null)
         {
             assembly ??= Assembly.GetCallingAssembly();
-
-            const BindingFlags methodFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-            Dictionary<CallOnUnloadAttribute, MethodInfo> methods = new();
-
-            // get all types
-            foreach (Type type in assembly.GetTypes())
-            {
-                // get all static methods
-                foreach (MethodInfo method in type.GetMethods(methodFlags))
-                {
-                    CallOnUnloadAttribute? attribute = method.GetCustomAttribute<CallOnUnloadAttribute>();
-                    if (attribute == null)
-                        continue;
-
-                    methods.Add(attribute, method);
-                }
-            }
-
-            foreach (KeyValuePair<CallOnUnloadAttribute, MethodInfo> method in methods.OrderBy(static v => v.Key.Priority))
-                method.Value.Invoke(null, null);
+            CallOnLoadAttribute.CallAttributeMethodPriority<CallOnUnloadAttribute>(assembly);
         }
 
         /// <inheritdoc/>

--- a/SecretAPI/Extensions/CollectionExtensions.cs
+++ b/SecretAPI/Extensions/CollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace SecretAPI.Extensions
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
@@ -16,6 +17,7 @@
         /// <param name="collection">The collection to pull from.</param>
         /// <typeparam name="T">The Type contained by the collection.</typeparam>
         /// <returns>A random value, default value when empty collection.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Will occur if the collection is empty.</exception>
         public static T GetRandomValue<T>(this IEnumerable<T> collection)
         {
             TryGetRandomValue(collection, out T? value);

--- a/SecretAPI/Extensions/RoleExtensions.cs
+++ b/SecretAPI/Extensions/RoleExtensions.cs
@@ -11,6 +11,7 @@
     /// <summary>
     /// Extensions related to <see cref="RoleTypeId"/>.
     /// </summary>
+    [Obsolete("This no longer provides anything that basegame/LabAPI does not")]
     public static class RoleExtensions
     {
         /// <summary>

--- a/SecretAPI/Extensions/RoleExtensions.cs
+++ b/SecretAPI/Extensions/RoleExtensions.cs
@@ -1,10 +1,11 @@
 ﻿namespace SecretAPI.Extensions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using InventorySystem;
-    using InventorySystem.Configs;
+    using LabApi.Features.Extensions;
     using PlayerRoles;
-    using PlayerRoles.FirstPersonControl;
+    using Respawning.Objectives;
     using UnityEngine;
 
     /// <summary>
@@ -19,16 +20,18 @@
         /// <param name="role">The <see cref="PlayerRoleBase"/> found.</param>
         /// <typeparam name="T">The <see cref="PlayerRoleBase"/>.</typeparam>
         /// <returns>The role base found, else null. </returns>
+        [Obsolete("Use LabApi.Features.Extensions.RoleExtensions.TryGetRoleBase")]
         public static bool TryGetRoleBase<T>(this RoleTypeId roleTypeId, [NotNullWhen(true)] out T? role)
-            => PlayerRoleLoader.TryGetRoleTemplate(roleTypeId, out role);
+            => LabApi.Features.Extensions.RoleExtensions.TryGetRoleBase(roleTypeId, out role);
 
         /// <summary>
         /// Gets the color of a <see cref="RoleTypeId"/>.
         /// </summary>
         /// <param name="roleTypeId">The role to get color of.</param>
         /// <returns>The color found, if not found then white.</returns>
+        [Obsolete("Use Respawning.Objectives.GetRoleColor")]
         public static Color GetColor(this RoleTypeId roleTypeId)
-            => TryGetRoleBase(roleTypeId, out PlayerRoleBase? role) ? role.RoleColor : Color.white;
+            => roleTypeId.GetRoleColor();
 
         /// <summary>
         /// Tries to get a random spawn point from a <see cref="RoleTypeId"/>.
@@ -37,24 +40,17 @@
         /// <param name="position">The position found.</param>
         /// <param name="horizontalRot">The rotation found.</param>
         /// <returns>Whether a spawnpoint was found.</returns>
+        [Obsolete("Use LabApi.Features.Extensions.RoleExtensions.TryGetRandomSpawnPoint")]
         public static bool GetRandomSpawnPosition(this RoleTypeId role, out Vector3 position, out float horizontalRot)
-        {
-            if (TryGetRoleBase(role, out IFpcRole? fpc))
-                return fpc.SpawnpointHandler.TryGetSpawnpoint(out position, out horizontalRot);
-
-            position = Vector3.zero;
-            horizontalRot = 0f;
-            return false;
-        }
+            => role.TryGetRandomSpawnPoint(out position, out horizontalRot);
 
         /// <summary>
         /// Gets the inventory of the specified <see cref="RoleTypeId"/>.
         /// </summary>
         /// <param name="role">The <see cref="RoleTypeId"/>.</param>
         /// <returns>The <see cref="InventoryRoleInfo"/> found.</returns>
+        [Obsolete("Use LabApi.Features.Extensions.RoleExtensions.GetInventory")]
         public static InventoryRoleInfo GetInventory(this RoleTypeId role)
-            => StartingInventories.DefinedInventories.TryGetValue(role, out InventoryRoleInfo info)
-                ? info
-                : new InventoryRoleInfo([], []);
+            => LabApi.Features.Extensions.RoleExtensions.GetInventory(role);
     }
 }

--- a/SecretAPI/Extensions/RoomExtensions.cs
+++ b/SecretAPI/Extensions/RoomExtensions.cs
@@ -14,7 +14,9 @@
         [
             RoomName.HczTesla, // Instant death
             RoomName.EzEvacShelter, // Stuck permanently
-            RoomName.EzCollapsedTunnel // Stuck permanently
+            RoomName.EzCollapsedTunnel, // Stuck permanently
+            RoomName.HczWaysideIncinerator, // Death
+            RoomName.Hcz096, // Void
         ];
 
         /// <summary>

--- a/SecretAPI/Features/IPriority.cs
+++ b/SecretAPI/Features/IPriority.cs
@@ -1,0 +1,13 @@
+﻿namespace SecretAPI.Features
+{
+    /// <summary>
+    /// Handles IPriority.
+    /// </summary>
+    public interface IPriority
+    {
+        /// <summary>
+        /// Gets the current priority.
+        /// </summary>
+        public int Priority { get; }
+    }
+}

--- a/SecretAPI/SecretAPI.csproj
+++ b/SecretAPI/SecretAPI.csproj
@@ -29,7 +29,7 @@
 
     <ItemGroup>
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
-        <PackageReference Include="Northwood.LabAPI" Version="1.1.3" IncludeAssets="All" PrivateAssets="All" />
+        <PackageReference Include="Northwood.LabAPI" Version="1.1.4" IncludeAssets="All" PrivateAssets="All" />
         <PackageReference Include="Lib.Harmony" Version="2.2.2" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" IncludeAssets="All" PrivateAssets="All" />
     </ItemGroup>

--- a/SecretAPI/SecretAPI.csproj
+++ b/SecretAPI/SecretAPI.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net48</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>2.0.1</Version>
+        <Version>2.0.2</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/SecretAPI/SecretApi.cs
+++ b/SecretAPI/SecretApi.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Reflection;
     using HarmonyLib;
+    using LabApi.Features;
     using LabApi.Loader.Features.Plugins;
     using LabApi.Loader.Features.Plugins.Enums;
     using SecretAPI.Attribute;
@@ -28,10 +29,11 @@
         public override Version Version { get; } = Assembly.GetName().Version;
 
         /// <inheritdoc/>
-        public override Version RequiredApiVersion { get; } = new(LabApi.Features.LabApiProperties.CompiledVersion);
+        public override Version RequiredApiVersion => LabApiProperties.CurrentVersion;
 
-        /*/// <inheritdoc />
-        public override bool IsTransparent => true;*/
+        /// <inheritdoc />
+        /// <remarks>We use transparent here because this is an API and should not interfere by itself with game logic.</remarks>
+        public override bool IsTransparent => true;
 
         /// <summary>
         /// Gets the harmony to use for the API.


### PR DESCRIPTION
# Obsoletes
- All of ``RoleExtensions`` has been obsoleted, in favor of their basegame/labapi counterparts
## Additions
- ``IPriority`` interface - Used by ``CallOnLoadAttribute``/``CallOnUnloadAttribute``
# Changes
- SecretAPI will now be considered Transparent (On its own should no longer add modded tag to a server)
- ``RoomExtensions`` now considers ``HczWaysideIncinerator`` & ``Hcz096`` as invalid rooms