### PR TITLE
Update examples

### DIFF
--- a/SecretAPI.Examples/Settings/ExampleDropdownSetting.cs
+++ b/SecretAPI.Examples/Settings/ExampleDropdownSetting.cs
@@ -38,7 +38,7 @@
         /// <inheritdoc/>
         protected override void HandleSettingUpdate()
         {
-            Logger.Info($"{KnownOwner?.DisplayName ?? "null reference"} selected {SelectedOption} (Index {ValidatedSelectedIndex}/{Options.Length})");
+            Logger.Info($"{KnownOwner?.DisplayName ?? "(Null Owner - What went wrong?)"} selected {SelectedOption} (Index {ValidatedSelectedIndex}/{Options.Length - 1})");
         }
     }
 }

--- a/SecretAPI.Examples/Settings/ExampleKeybindSetting.cs
+++ b/SecretAPI.Examples/Settings/ExampleKeybindSetting.cs
@@ -1,5 +1,6 @@
 namespace SecretAPI.Examples.Settings
 {
+    using LabApi.Features.Wrappers;
     using SecretAPI.Features.UserSettings;
     using UnityEngine;
 
@@ -18,6 +19,9 @@ namespace SecretAPI.Examples.Settings
 
         /// <inheritdoc />
         public override CustomHeader Header => CustomHeader.Examples;
+
+        /// <inheritdoc/>
+        protected override bool CanView(Player player) => player.RemoteAdminAccess;
 
         /// <inheritdoc />
         protected override CustomSetting CreateDuplicate() => new ExampleKeybindSetting();


### PR DESCRIPTION
Fix: ``ExampleDropdownSetting::HandleSettingUpdate`` displaying incorrect index
Change: Make ``ExampleKeybindSetting`` require a player to have remote admin access